### PR TITLE
Don't steal other's floating IP

### DIFF
--- a/run_ocp.sh
+++ b/run_ocp.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
+
 set -x
 set -e
 
 source "${CONFIG}"
-# check whether we already have a floating ip created
-FLOATING_IP=$(openstack floating ip list --format value | awk -F ' ' 'NR==1 {print $2}')
+
+# check whether we have a free floating IP
+FLOATING_IP=$(openstack floating ip list --status DOWN --format value | awk -F ' ' 'NR==1 {print $2}')
 
 # create new floating ip if doesn't exist
 if [ -z "$FLOATING_IP" ]; then
-    FLOATING_IP=$(openstack floating ip create $OPENSTACK_EXTERNAL_NETWORK --format value | awk 'NR==6')
+    FLOATING_IP=$(openstack floating ip create $OPENSTACK_EXTERNAL_NETWORK --format value --column floating_ip_address)
 fi
 
 # add data to /etc/hosts


### PR DESCRIPTION
We check if there's an *available* floating IP we can use, we don't
want to be debugging duplicate IP address issues in the tenant.

Also make retrieving the newly floating IP more robust. Previously it
was getting a UUID instead of the IP against MOC.