### PR TITLE
Reduce machineCIDR not to conflict with upshift endpoints

### DIFF
--- a/run_ocp.sh
+++ b/run_ocp.sh
@@ -80,7 +80,7 @@ networking:
   - cidr:             10.128.0.0/14
     hostSubnetLength: 9
   serviceCIDR: 172.30.0.0/16
-  machineCIDR: 10.0.0.0/16
+  machineCIDR: 10.0.128.0/17
   type:        OpenshiftSDN
 platform:
   openstack:


### PR DESCRIPTION
Use a smaller IP range for machineCIDR so that id doesn't include the
IP of the Upshift endpoints.