### PR TITLE
Fix issue where build_mco.sh omits the username when pushing

### DIFF
--- a/build_mco.sh
+++ b/build_mco.sh
@@ -7,9 +7,6 @@ help() {
     echo ""
 }
 
-export DEST_IMAGE="quay.io/$USERNAME/origin-release:mco"
-export FROM_IMAGE="registry.svc.ci.openshift.org/origin/release:4.2"
-
 # Parse Options
 case $1 in
     -h|--help)
@@ -24,6 +21,10 @@ if [ -z "$1" ]; then
 fi
 
 USERNAME="$1"
+
+export DEST_IMAGE="quay.io/$USERNAME/origin-release:mco"
+export FROM_IMAGE="registry.svc.ci.openshift.org/origin/release:4.2"
+
 pushd $GOPATH/src/github.com/openshift/machine-config-operator
 for image in controller daemon operator server; do
     export WHAT=machine-config-$image
@@ -36,5 +37,13 @@ for image in controller daemon operator server; do
     ./hack/push-image.sh
 done
 
-oc adm release new --from-release="$FROM_IMAGE" --server https://api.ci.openshift.org -n openshift --to-image="$DEST_IMAGE" machine-config-operator=quay.io/$USERNAME/origin-machine-config-operator:latest machine-config-controller=quay.io/$USERNAME/origin-machine-config-controller:latest machine-config-daemon=quay.io/$USERNAME/origin-machine-config-daemon:latest machine-config-server=quay.io/$USERNAME/origin-machine-config-server:latest
+oc adm release new \
+    --from-release="$FROM_IMAGE" \
+    --to-image="$DEST_IMAGE" \
+    --server https://api.ci.openshift.org \
+    -n openshift \
+    machine-config-operator=quay.io/$USERNAME/origin-machine-config-operator:latest \
+    machine-config-controller=quay.io/$USERNAME/origin-machine-config-controller:latest \
+    machine-config-daemon=quay.io/$USERNAME/origin-machine-config-daemon:latest \
+    machine-config-server=quay.io/$USERNAME/origin-machine-config-server:latest
 popd


### PR DESCRIPTION
The DEST_IMAGE environment variable needs to be initialized after the
USERNAME one, otherwise the script tries to push images to
quay.io/origin-release:mco instead of the user's namespaced registry.