### PR TITLE
Check for available floating IP on the external network

### DIFF
--- a/run_ocp.sh
+++ b/run_ocp.sh
@@ -13,7 +13,7 @@ source ${CONFIG}
 set -x
 
 # check whether we have a free floating IP
-FLOATING_IP=$(openstack floating ip list --status DOWN --format value | awk -F ' ' 'NR==1 {print $2}')
+FLOATING_IP=$(openstack floating ip list --status DOWN --network $OPENSTACK_EXTERNAL_NETWORK --format value | awk -F ' ' 'NR==1 {print $2}')
 
 # create new floating ip if doesn't exist
 if [ -z "$FLOATING_IP" ]; then


### PR DESCRIPTION
Otherwise it could pick floating IPs from different networks and fail
the installation with a cryptic neutron error indicating no more IP
addresses are available on the external network.